### PR TITLE
Fix rails requires

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,16 +1,6 @@
 require_relative 'boot'
 
-# require "rails"
-# Pick the frameworks you want:
-require "active_model/railtie"
-# require "active_job/railtie"
-require "active_record/railtie"
-require "action_controller/railtie"
-require "action_mailer/railtie"
-require "action_view/railtie"
-# require "action_cable/engine"
-require "sprockets/railtie"
-require "rails/test_unit/railtie"
+require 'rails/all'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.


### PR DESCRIPTION
This is a tricky one: I copy/pasted the requires from a clean rail 5.0.0 final project. I don't know if the old content of this file is the old rails default content, or if it's something we added ourselves for reasons. 

@bitTal you mentioned the previous `require rails` caused an error, it would be nice if you could test what you think might have been broken by it, so we can look into the underlying problem

@simaob you probably understand better than anyone what all those `requires` are doing there, can you think of anything that is NOT included in `rails/all`?
