### PR TITLE
Removes integration with S3, so that we can use the file system

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ gem "i18n-js", ">= 3.0.0.rc11"
 gem 'puma', '~> 3.0'
 
 gem 'paperclip'
-gem 'aws-sdk', '~> 2.3'
 
 gem 'dotenv-rails'
 gem 'devise'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,12 +53,6 @@ GEM
     arel (7.0.0)
     autoprefixer-rails (6.3.7)
       execjs
-    aws-sdk (2.6.4)
-      aws-sdk-resources (= 2.6.4)
-    aws-sdk-core (2.6.4)
-      jmespath (~> 1.0)
-    aws-sdk-resources (2.6.4)
-      aws-sdk-core (= 2.6.4)
     babel-source (5.8.35)
     babel-transpiler (0.7.0)
       babel-source (>= 4.0, < 6)
@@ -113,7 +107,6 @@ GEM
     jbuilder (2.5.0)
       activesupport (>= 3.0.0, < 5.1)
       multi_json (~> 1.2)
-    jmespath (1.3.1)
     jquery-rails (4.1.1)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -259,7 +252,6 @@ DEPENDENCIES
   activerecord-sortable
   acts-as-taggable-on (~> 4.0)
   annotate
-  aws-sdk (~> 2.3)
   bootstrap (~> 4.0.0.alpha3)
   bootstrap-datepicker-rails
   browserify-rails

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -85,14 +85,4 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
-
-  config.paperclip_defaults = {
-    storage: :s3,
-    s3_credentials: {
-      bucket: ENV.fetch('S3_BUCKET_NAME'),
-      access_key_id: ENV.fetch('AWS_ACCESS_KEY_ID'),
-      secret_access_key: ENV.fetch('AWS_SECRET_ACCESS_KEY'),
-      s3_region: ENV.fetch('AWS_REGION'),
-    }
-  }
 end

--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -1,6 +1,0 @@
-# config/initializers/paperclip.rb
-if Rails.env == "production"
-  Paperclip::Attachment.default_options[:url] = ':s3_domain_url'
-  Paperclip::Attachment.default_options[:path] = '/:class/:attachment/:id_partition/:style/:filename'
-end
-


### PR DESCRIPTION
This PR removes the integration with S3. And starts using the file system to store the uploaded images.

This wasn't an option on Heroku as the files are removed with each new deploy, but once the app is deployed to a VPS shouldn't be an issue anymore and removes the dependency from S3.